### PR TITLE
Handle fallback and peer discovery errors

### DIFF
--- a/Fucker/app/src/main/java/com/example/fucker/NetworkUtils.kt
+++ b/Fucker/app/src/main/java/com/example/fucker/NetworkUtils.kt
@@ -1,0 +1,8 @@
+package com.example.fucker
+
+// Checks if two IPs are on the same /24 subnet
+fun isSameSubnet(ip1: String, ip2: String): Boolean {
+    val subnet1 = ip1.substringBeforeLast('.')
+    val subnet2 = ip2.substringBeforeLast('.')
+    return subnet1 == subnet2
+}

--- a/Fucker/app/src/test/java/com/example/fucker/NetworkUtilsTest.kt
+++ b/Fucker/app/src/test/java/com/example/fucker/NetworkUtilsTest.kt
@@ -1,0 +1,13 @@
+package com.example.fucker
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NetworkUtilsTest {
+    @Test
+    fun testIsSameSubnet() {
+        assertTrue(isSameSubnet("192.168.1.5", "192.168.1.10"))
+        assertFalse(isSameSubnet("192.168.1.5", "192.168.2.10"))
+    }
+}


### PR DESCRIPTION
## Summary
- wrap peer discovery in try/catch and log failures consistently
- guard P2P fallback with try/catch to avoid uncaught exceptions
- extract subnet helper into NetworkUtils with accompanying unit test

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b78b1d91708332ac4408ad1e10d21b