### PR TITLE
chore: remove jcenter repository

### DIFF
--- a/Fucker/settings.gradle
+++ b/Fucker/settings.gradle
@@ -3,7 +3,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        jcenter() // Warning: this repository is going to shut down soon
     }
 }
 rootProject.name = "UnseenNotes"


### PR DESCRIPTION
## Summary
- drop jcenter from Gradle repositories

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a37aa514833299b87d0f4584e4fe