### PR TITLE
Update Android build configuration to API 34 and Java 17

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
       - name: Install Android SDK
         run: |
           bash scripts/setup-android-sdk.sh

--- a/Fucker/app/build.gradle
+++ b/Fucker/app/build.gradle
@@ -3,14 +3,14 @@ plugins {
 }
 
 android {
-    compileSdk 31
-    buildToolsVersion "31.0.0"
+    compileSdk 34
+    buildToolsVersion "34.0.0"
     namespace "PKG.Unseennotes"
 
     defaultConfig {
         applicationId "PKG.Unseennotes"
         minSdk 21
-        targetSdk 31
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 

--- a/scripts/setup-android-sdk.sh
+++ b/scripts/setup-android-sdk.sh
@@ -12,6 +12,12 @@ fi
 export ANDROID_SDK_ROOT="$SDK_ROOT"
 set +o pipefail
 yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --sdk_root="$ANDROID_SDK_ROOT" \
-  "platform-tools" "platforms;android-31" "build-tools;31.0.0"
+  "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+export PATH="$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/build-tools/34.0.0:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH"
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "$ANDROID_SDK_ROOT/platform-tools" >> "$GITHUB_PATH"
+  echo "$ANDROID_SDK_ROOT/build-tools/34.0.0" >> "$GITHUB_PATH"
+  echo "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin" >> "$GITHUB_PATH"
+fi
 set -o pipefail
 echo "sdk.dir=$ANDROID_SDK_ROOT" > "Fucker/local.properties"


### PR DESCRIPTION
## Summary
- bump Android app module to target/compile SDK 34 with build-tools 34.0.0
- install Android 34 platform and build tools in setup script and expose tools on PATH
- run CI with Temurin Java 17 before Gradle

## Testing
- `bash scripts/setup-android-sdk.sh` *(warning: This version only understands SDK XML versions up to 3 but an SDK XML file of version 4 was encountered.)*
- `gradle test --no-daemon --console=plain` *(fails: duplicate class PKG.Unseennotes.ExampleUnitTest)*


------
https://chatgpt.com/codex/tasks/task_e_68b9fe52583c83328928460140b66489