### PR TITLE
chore: target Java 17 and refresh dependencies

### DIFF
--- a/Fucker/app/build.gradle
+++ b/Fucker/app/build.gradle
@@ -24,16 +24,15 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 
 dependencies {
-
-    implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.4.0'
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation 'androidx.appcompat:appcompat:1.7.1'
+    implementation 'com.google.android.material:material:1.13.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }


### PR DESCRIPTION
## Summary
- target Java 17 for compilation
- update Android and test dependencies to latest stable versions

## Testing
- `ANDROID_HOME=/usr/lib/android-sdk gradle test` *(fails: missing Android SDK Platform 34 and Build-Tools 34)*

------
https://chatgpt.com/codex/tasks/task_e_68ba00794c5883329fe2524989797a24