### PR TITLE
chore: accept android sdk licenses

### DIFF
--- a/scripts/setup-android-sdk.sh
+++ b/scripts/setup-android-sdk.sh
@@ -13,6 +13,7 @@ export ANDROID_SDK_ROOT="$SDK_ROOT"
 set +o pipefail
 yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --sdk_root="$ANDROID_SDK_ROOT" \
   "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --licenses
 export PATH="$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/build-tools/34.0.0:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH"
 if [[ -n "${GITHUB_PATH:-}" ]]; then
   echo "$ANDROID_SDK_ROOT/platform-tools" >> "$GITHUB_PATH"

--- a/scripts/test-setup-android-sdk.sh
+++ b/scripts/test-setup-android-sdk.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TMP_DIR=$(mktemp -d)
+mkdir -p "$TMP_DIR/cmdline-tools/latest/bin"
+cat <<'SCRIPT' > "$TMP_DIR/cmdline-tools/latest/bin/sdkmanager"
+#!/usr/bin/env bash
+echo "sdkmanager stub $@"
+exit 0
+SCRIPT
+chmod +x "$TMP_DIR/cmdline-tools/latest/bin/sdkmanager"
+cleanup() {
+  rm -rf "$TMP_DIR"
+  rm -f Fucker/local.properties
+}
+trap cleanup EXIT
+ANDROID_SDK_ROOT="$TMP_DIR" ./scripts/setup-android-sdk.sh >/tmp/setup-run1.log 2>&1
+ANDROID_SDK_ROOT="$TMP_DIR" ./scripts/setup-android-sdk.sh >/tmp/setup-run2.log 2>&1
+echo "setup script ran twice successfully"


### PR DESCRIPTION
## Summary
- accept Android SDK licenses after installing required components
- add test to ensure setup script runs cleanly on repeated invocation

## Testing
- `bash scripts/test-setup-android-sdk.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ba02eb0a9c8332b1cd4d6e98dd78bc