### PR TITLE
Add unit and socket integration tests

### DIFF
--- a/Fucker/app/src/androidTest/java/com/example/fucker/SocketCommunicationTest.kt
+++ b/Fucker/app/src/androidTest/java/com/example/fucker/SocketCommunicationTest.kt
@@ -1,0 +1,71 @@
+package com.example.fucker
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+import java.net.ServerSocket
+import java.net.Socket
+import javax.crypto.spec.SecretKeySpec
+
+@RunWith(AndroidJUnit4::class)
+class SocketCommunicationTest {
+    private fun getPrivateMethod(name: String, vararg params: Class<*>): java.lang.reflect.Method {
+        val m = MainActivity::class.java.getDeclaredMethod(name, *params)
+        m.isAccessible = true
+        return m
+    }
+
+    private fun setAesKey(activity: MainActivity, key: SecretKeySpec) {
+        val f = MainActivity::class.java.getDeclaredField("aesKey")
+        f.isAccessible = true
+        f.set(activity, key)
+    }
+
+    @Test
+    fun socket_sendReceive_encrypted() {
+        val keyBytes = ByteArray(32) { 3 }
+        val key = SecretKeySpec(keyBytes, "AES")
+        val serverActivity = MainActivity()
+        val clientActivity = MainActivity()
+        setAesKey(serverActivity, key)
+        setAesKey(clientActivity, key)
+        val encrypt = getPrivateMethod("encryptMessage", String::class.java)
+        val decrypt = getPrivateMethod("decryptMessage", String::class.java)
+
+        val server = ServerSocket(0)
+        val port = server.localPort
+        var serverReceived: String? = null
+        val serverThread = Thread {
+            val socket = server.accept()
+            val reader = BufferedReader(InputStreamReader(socket.getInputStream()))
+            val writer = PrintWriter(OutputStreamWriter(socket.getOutputStream()), true)
+            val enc = reader.readLine()
+            val msg = decrypt.invoke(serverActivity, enc) as String
+            serverReceived = msg
+            val replyEnc = encrypt.invoke(serverActivity, "ACK:$msg") as String
+            writer.println(replyEnc)
+            socket.close()
+            server.close()
+        }
+        serverThread.start()
+
+        val clientSocket = Socket("127.0.0.1", port)
+        val reader = BufferedReader(InputStreamReader(clientSocket.getInputStream()))
+        val writer = PrintWriter(OutputStreamWriter(clientSocket.getOutputStream()), true)
+        val enc = encrypt.invoke(clientActivity, "Hello") as String
+        writer.println(enc)
+        val replyEnc = reader.readLine()
+        val reply = decrypt.invoke(clientActivity, replyEnc) as String
+        clientSocket.close()
+        serverThread.join()
+
+        assertEquals("Hello", serverReceived)
+        assertEquals("ACK:Hello", reply)
+    }
+}
+

--- a/Fucker/app/src/test/java/com/example/fucker/MainActivityCryptoTest.kt
+++ b/Fucker/app/src/test/java/com/example/fucker/MainActivityCryptoTest.kt
@@ -1,0 +1,69 @@
+package com.example.fucker
+
+import org.junit.Assert.*
+import org.junit.Test
+import javax.crypto.spec.SecretKeySpec
+
+class MainActivityCryptoTest {
+    private fun getPrivateMethod(name: String, vararg params: Class<*>): java.lang.reflect.Method {
+        val m = MainActivity::class.java.getDeclaredMethod(name, *params)
+        m.isAccessible = true
+        return m
+    }
+
+    private fun getAesKeyField(): java.lang.reflect.Field {
+        val f = MainActivity::class.java.getDeclaredField("aesKey")
+        f.isAccessible = true
+        return f
+    }
+
+    @Test
+    fun hkdf_producesExpectedKey() {
+        val activity = MainActivity()
+        val hkdf = getPrivateMethod("hkdf", ByteArray::class.java, Int::class.javaPrimitiveType)
+        val secret = "supersecret".toByteArray(Charsets.UTF_8)
+        val derived = hkdf.invoke(activity, secret, 32) as ByteArray
+        val expected = byteArrayOf(
+            0x78.toByte(),0xF2.toByte(),0xD7.toByte(),0xEA.toByte(),0xB7.toByte(),0x3D.toByte(),0x62.toByte(),0x9C.toByte(),
+            0x04.toByte(),0x14.toByte(),0x26.toByte(),0x69.toByte(),0xD6.toByte(),0x71.toByte(),0x1A.toByte(),0xA2.toByte(),
+            0x17.toByte(),0xEA.toByte(),0x8D.toByte(),0xA5.toByte(),0x16.toByte(),0x63.toByte(),0x69.toByte(),0x2E.toByte(),
+            0x83.toByte(),0xBE.toByte(),0xA6.toByte(),0xAD.toByte(),0x5B.toByte(),0x52.toByte(),0x0F.toByte(),0x0A.toByte()
+        )
+        assertArrayEquals(expected, derived)
+    }
+
+    @Test
+    fun encryptDecrypt_roundTrip() {
+        val activity = MainActivity()
+        val keyBytes = ByteArray(32) { 1 }
+        val key = SecretKeySpec(keyBytes, "AES")
+        getAesKeyField().set(activity, key)
+        val encrypt = getPrivateMethod("encryptMessage", String::class.java)
+        val decrypt = getPrivateMethod("decryptMessage", String::class.java)
+        val message = "Hello World"
+        val encrypted = encrypt.invoke(activity, message) as String
+        assertNotEquals("", encrypted)
+        val decrypted = decrypt.invoke(activity, encrypted) as String
+        assertEquals(message, decrypted)
+    }
+
+    @Test
+    fun encrypt_withoutKey_returnsEmpty() {
+        val activity = MainActivity()
+        val encrypt = getPrivateMethod("encryptMessage", String::class.java)
+        val result = encrypt.invoke(activity, "test") as String
+        assertEquals("", result)
+    }
+
+    @Test
+    fun decrypt_invalidInput_returnsEmpty() {
+        val activity = MainActivity()
+        val keyBytes = ByteArray(32) { 2 }
+        val key = SecretKeySpec(keyBytes, "AES")
+        getAesKeyField().set(activity, key)
+        val decrypt = getPrivateMethod("decryptMessage", String::class.java)
+        val result = decrypt.invoke(activity, "not_base64") as String
+        assertEquals("", result)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add reflection-based tests for MainActivity HKDF, encryption, and decryption helpers
- introduce instrumentation test simulating encrypted socket communication

## Testing
- `gradle test` *(fails: SDK location not found)*
- `gradle connectedAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0e2fe3e883329ab1c13c6bab4bcf